### PR TITLE
sql.y: fix compilation error due to multiple definitions

### DIFF
--- a/sql.y
+++ b/sql.y
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+
+char *filename;
 %}
 
 %define api.pure
@@ -28,7 +30,7 @@
 %lex-param { yyscan_t scanner }
 
 %code requires {
-char *filename;
+extern char *filename;
 
 #include "yyl.h"
 


### PR DESCRIPTION
I assume it used not to be a problem with whichever compiler sqlfun was tested with, but to build with a reasonably recent gcc, this patch is required.