### PR TITLE
Correct lexx invocation in Makefile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,8 +48,10 @@ CLEANFILES = $(nodist_sql_SOURCES) sql.output
 sql.tab.c sql.tab.h:   sql.y Makefile
 	${BISON} -vd $<
 
-sql.c sql.lex.h: sql.l Makefile
+sql.c: sql.l Makefile
 	${LEX} -o $@ $<
+
+sql.lex.h: sql.c ;
 
 TESTS = test-ok.sh test-fail.sh test-tst.sh
 


### PR DESCRIPTION
Previously, calling make sql.lex.h would cause lexx to only generate sql.lex.h, and generate it incorrectly. This change makes the sql.lex.h rule depend on the sql.c rule, causing the call to lexx to generate both files, and then sql.lex.h is generated correctly.